### PR TITLE
Make package compatible with django 3

### DIFF
--- a/django_ranger/models.py
+++ b/django_ranger/models.py
@@ -4,12 +4,10 @@ from collections import Counter
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from .validations import ValidatingGrantModel
 
 
-@python_2_unicode_compatible
 class Permission(models.Model):
     """
     A model class that stores permissions. It represents

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-ranger',
-    version='0.4.1',
+    version='0.4.2',
     packages=['django_ranger', 'django_ranger.migrations'],
     include_package_data=True,
     license='BSD License',
@@ -25,7 +25,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content'
     ]


### PR DESCRIPTION
## Purpose
Make the library compatible with django 3, dropping the support for python 2.

## Approach
Use the osvaldo branch to advance the version of the `setup.py` and dropping the usage of deleted django utils.
